### PR TITLE
update lambda_function.py

### DIFF
--- a/lambda_function.py
+++ b/lambda_function.py
@@ -14,7 +14,7 @@ import urllib2
 
 from boto3.dynamodb.conditions import Key
 from boto3.session import Session
-from PIL import ImageOps
+from PIL import Image, ImageOps
 from twilio.rest import TwilioRestClient
 
 
@@ -80,7 +80,7 @@ def lambda_handler(event, context):
         # build meta data
         m_data = {'fromNumber': from_number, 'url': resp_url, 'name': name}
         output = StringIO.StringIO()
-        im.save(output)
+        im.save(output, format="PNG")
         im_data = output.getvalue()
         output.close()
 


### PR DESCRIPTION
added Image lib and image format. When testing the lambda function was breaking for two reasons: 1) the Image python library wasn't included > line 71
2) an image format needed to be specified when saving, otherwise a it created a Key: '' error > line 83 > https://stackoverflow.com/questions/646286/python-pil-how-to-write-png-image-to-string/646297#646297