### PR TITLE
remove phone_number from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,6 @@ Clone this repo and update `lambda_function.py`.
 # lambda_function.py
 account_sid = "account_sid" # Twilio account SID
 auth_token = "auth_token" # Twilio auth token
-phone_number = "phone_number" # Twilio phone number
 dynamodb = boto3.resource('dynamodb', '_region') # AWS region set in Pre-Requisites
 table_users = dynamodb.Table('table_name') # name of DyanmoDB created in Pre-Requisites
 ```


### PR DESCRIPTION
The phone_number field was removed from the source code in bc783e5ee648e847b31e5bf263fad25758d8abf5, let's remove it from the docs as well.